### PR TITLE
FPO-184: Make concurrency configurable per application

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 3
 ```
 
 The meaning of these configuration items is as follows:
@@ -48,14 +49,15 @@ The meaning of these configuration items is as follows:
 | Field Name                         | Description |
 |------------------------------------|-------------|
 | `Name`                             | The name of the application configuration (seen in the status page). |
-| `URL`                              | The URL associated with the application, used for network requests. |
-| `AuthHeaderValue` (optional)       | The value to be used for the authorization header in network requests. (e.g. `env:API_KEY`). These are injected at deploy time  |
-| `AuthHeader` (optional)            | The key/name of the authorization header to use in network requests (e.g. X-Api-Key or Authorization). |
-| `Verb` (defaults to "GET")         | The HTTP method (verb) to be used in network requests, such as `GET`, `POST`, etc. |
-| `Data` (optional)                  | The data to be sent in the body of network requests, if applicable. |
-| `ErrorHighWatermarkPercentage`     | The high watermark percentage for error rates beyond which an application is considered to be in a `INACTIVE` state. |
-| `ErrorMediumWatermarkPercentage`   | The medium watermark percentage for error rates that indicate a `DEGRADED` but acceptable state. |
-| `ErrorLowWatermarkPercentage`      | The low watermark percentage for error rates considered `ACTIVE` under normal operation. |
-| `P90HighWatermarkSeconds`          | The high watermark for 90th percentile response times, above which performance is considered `INACTIVE`. |
-| `P90MediumWatermarkSeconds`        | The medium watermark for 90th percentile response times, indicating caution but not necessarily `DEGRADED` state. |
-| `P90LowWatermarkSeconds`           | The low watermark for 90th percentile response times, considered `ACTIVE` under normal conditions. |
+| `url`                              | The URL associated with the application, used for network requests. |
+| `authHeader` (optional)            | The key/name of the authorization header to use in network requests (e.g. X-Api-Key or Authorization). |
+| `authHeaderValue` (optional)       | The value to be used for the authorization header in network requests. (e.g. `env:API_KEY`). These are injected at deploy time  |
+| `verb` (defaults to "GET")         | The HTTP method (verb) to be used in network requests, such as `GET`, `POST`, etc. |
+| `data` (optional)                  | The data to be sent in the body of network requests, if applicable. |
+| `errorHighWatermarkPercentage`     | The high watermark percentage for error rates beyond which an application is considered to be in a `INACTIVE` state. |
+| `errorMediumWatermarkPercentage`   | The medium watermark percentage for error rates that indicate a `DEGRADED` but acceptable state. |
+| `errorLowWatermarkPercentage`      | The low watermark percentage for error rates considered `ACTIVE` under normal operation. |
+| `p90HighWatermarkSeconds`          | The high watermark for 90th percentile response times, above which performance is considered `INACTIVE`. |
+| `p90MediumWatermarkSeconds`        | The medium watermark for 90th percentile response times, indicating caution but not necessarily `DEGRADED` state. |
+| `p90LowWatermarkSeconds`           | The low watermark for 90th percentile response times, considered `ACTIVE` under normal conditions. |
+| `concurrency`                      | How many workers to execute concurrently for this application. |

--- a/config/applications.development.toml
+++ b/config/applications.development.toml
@@ -7,6 +7,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 6.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 2
 
 [[application]]
 name = "Trade Tariff Backend"
@@ -17,6 +18,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 5.0
 p90MediumWatermarkSeconds = 2.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 2
 
 [[application]]
 name = "Trade Tariff FPO Search"
@@ -31,6 +33,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 2
 
 [[application]]
 name = "Trade Tariff Duty Calculator"
@@ -41,6 +44,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 2
 
 [[application]]
 name = "Trade Tariff Admin"
@@ -51,6 +55,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 2
 
 [[application]]
 name = "Trade Tariff Developer Hub Frontend"
@@ -61,6 +66,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 2
 
 [[application]]
 name = "Trade Tariff Developer Hub Backend"
@@ -71,3 +77,4 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 2

--- a/config/applications.production.toml
+++ b/config/applications.production.toml
@@ -1,12 +1,13 @@
 [[application]]
 name = "Trade Tariff Frontend"
-url = "https://trade-tariff.service.gov.uk/commodities/0101210000"
+url = "https://www.trade-tariff.service.gov.uk/commodities/0101210000"
 errorHighWatermarkPercentage = 50.0
 errorMediumWatermarkPercentage = 20.0
 errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Backend"
@@ -17,6 +18,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 5.0
 p90MediumWatermarkSeconds = 2.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff FPO Search"
@@ -31,6 +33,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Duty Calculator"
@@ -41,6 +44,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Admin"
@@ -51,23 +55,26 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Developer Hub Frontend"
-url = "https://hub.staging.trade-tariff.service.gov.uk/healthcheck"
+url = "https://hub.production.trade-tariff.service.gov.uk/healthcheck"
 errorHighWatermarkPercentage = 50.0
 errorMediumWatermarkPercentage = 20.0
 errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Developer Hub Backend"
-url = "https://hub.staging.trade-tariff.service.gov.uk/api/healthcheck"
+url = "https://hub.production.trade-tariff.service.gov.uk/api/healthcheck"
 errorHighWatermarkPercentage = 50.0
 errorMediumWatermarkPercentage = 20.0
 errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5

--- a/config/applications.staging.toml
+++ b/config/applications.staging.toml
@@ -7,6 +7,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Backend"
@@ -17,6 +18,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 5.0
 p90MediumWatermarkSeconds = 2.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff FPO Search"
@@ -31,6 +33,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Duty Calculator"
@@ -41,6 +44,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Admin"
@@ -51,6 +55,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Developer Hub Frontend"
@@ -61,6 +66,7 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5
 
 [[application]]
 name = "Trade Tariff Developer Hub Backend"
@@ -71,3 +77,4 @@ errorLowWatermarkPercentage = 1.0
 p90HighWatermarkSeconds = 10.0
 p90MediumWatermarkSeconds = 3.0
 p90LowWatermarkSeconds = 1.0
+concurrency = 5


### PR DESCRIPTION
### Jira link

FPO-184

### What?

I have added/removed/altered:

- [x] Added ability to configure concurrency per environment/per application

### Why?

I am doing this because:

- We want to hit development with fewer requests to avoid tripping the WAF
rate limits
